### PR TITLE
SwordsModAttributes.ENDERMAN_FRIENDLY: use mixin on Fabric and event on NeoForge

### DIFF
--- a/common/src/main/java/com/samsthenerd/monthofswords/mixins/MixinLivEntJump.java
+++ b/common/src/main/java/com/samsthenerd/monthofswords/mixins/MixinLivEntJump.java
@@ -2,14 +2,12 @@ package com.samsthenerd.monthofswords.mixins;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.samsthenerd.monthofswords.items.WovenSwordItem;
-import com.samsthenerd.monthofswords.registry.SwordsModAttributes;
 import com.samsthenerd.monthofswords.registry.SwordsModItems;
 import com.samsthenerd.monthofswords.registry.SwordsModStatusEffects.FriendOfEntityStatusEffect;
 import com.samsthenerd.monthofswords.utils.LivingEntDuck;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.Vec3d;
@@ -176,14 +174,6 @@ public abstract class MixinLivEntJump extends Entity implements LivingEntDuck {
 
         }
         return original;
-    }
-
-    @ModifyReturnValue(
-        method="createLivingAttributes", at=@At("RETURN")
-    )
-    private static DefaultAttributeContainer.Builder monthOfSwords$addDefaultLivingAttributes(DefaultAttributeContainer.Builder builder){
-        SwordsModAttributes.init();
-        return builder.add(SwordsModAttributes.ENDERMAN_FRIENDLY, 0);
     }
 
 //    @Inject(

--- a/fabric/src/main/java/com/samsthenerd/monthofswords/fabric/mixins/MixinLivEntAttributes.java
+++ b/fabric/src/main/java/com/samsthenerd/monthofswords/fabric/mixins/MixinLivEntAttributes.java
@@ -1,0 +1,19 @@
+package com.samsthenerd.monthofswords.fabric.mixins;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.samsthenerd.monthofswords.registry.SwordsModAttributes;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(LivingEntity.class)
+public class MixinLivEntAttributes {
+	@ModifyReturnValue(
+			method="createLivingAttributes", at=@At("RETURN")
+	)
+	private static DefaultAttributeContainer.Builder monthOfSwords$addDefaultLivingAttributes(DefaultAttributeContainer.Builder builder){
+		SwordsModAttributes.init();
+		return builder.add(SwordsModAttributes.ENDERMAN_FRIENDLY, 0);
+	}
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -26,7 +26,8 @@
     ]
   },
   "mixins": [
-    "monthofswords.mixins.json"
+    "monthofswords.mixins.json",
+    "monthofswords.fabric.mixins.json"
   ],
   "depends": {
     "fabricloader": ">=0.16.3",

--- a/fabric/src/main/resources/monthofswords.fabric.mixins.json
+++ b/fabric/src/main/resources/monthofswords.fabric.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "package": "com.samsthenerd.monthofswords.fabric.mixins",
+  "compatibilityLevel": "JAVA_21",
+  "minVersion": "0.8",
+  "client": [],
+  "mixins": [
+    "MixinLivEntAttributes"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.30.0
+mod_version = 1.30.1
 maven_group = com.samsthenerd.monthofswords
 archives_base_name = monthofswords
 mod_id =monthofswords

--- a/neoforge/src/main/java/com/samsthenerd/monthofswords/neoforge/SwordsModNeoForge.java
+++ b/neoforge/src/main/java/com/samsthenerd/monthofswords/neoforge/SwordsModNeoForge.java
@@ -2,10 +2,12 @@ package com.samsthenerd.monthofswords.neoforge;
 
 import com.samsthenerd.monthofswords.SwordsMod;
 import com.samsthenerd.monthofswords.neoforge.xplat.SwordsModXPlatNF;
+import com.samsthenerd.monthofswords.registry.SwordsModAttributes;
 import com.samsthenerd.monthofswords.registry.SwordsModDataAttachments;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.event.entity.EntityAttributeModificationEvent;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.RegisterEvent;
 
@@ -30,5 +32,12 @@ public final class SwordsModNeoForge {
                 }
             }
         );
+    }
+
+    @SubscribeEvent
+    public void entityAttributeModification(EntityAttributeModificationEvent event) {
+        for (var type : event.getTypes()) {
+            event.add(type, SwordsModAttributes.ENDERMAN_FRIENDLY, 0);
+        }
     }
 }


### PR DESCRIPTION
Sinytra Connector initializes Fabric mods before NeoForge mods. If a Fabric mod registers default attributes for an entity, Month of Swords' attributes will attempt registration too early, causing Architectury to throw an error about the mod list not being present and crashing the game.

This PR fixes that by continuing to use the mixin for registering Month of Swords' default attribute on Fabric, but using `EntityAttributeModificationEvent` instead on NeoForge.